### PR TITLE
feat(mesh): sync platform api to 1fb9aa34e8c4a2c6c62694b656289efbcd4280e7

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 322c4806-8b53-493c-a05f-50d4d113c747
 management:
-  docChecksum: a8f9fc3249fdb7f54f8b90f5edc5d458
+  docChecksum: b39182d4478d4836620852cb8e19f451
   docVersion: 2.0.0
   speakeasyVersion: 1.514.1
   generationVersion: 2.546.3
@@ -1820,7 +1820,7 @@ examples:
         path:
           name: "<value>"
       requestBody:
-        application/json: {"name": "<value>", "type": "<value>"}
+        application/json: {"name": "<value>", "skipCreatingInitialPolicies": [], "type": "<value>"}
       responses:
         "200":
           application/json: {}
@@ -1863,7 +1863,7 @@ examples:
           mesh: "<value>"
           name: "<value>"
       requestBody:
-        application/json: {"mesh": "<value>", "name": "<value>", "type": "<value>"}
+        application/json: {"mesh": "<value>", "name": "<value>", "selectors": [], "type": "<value>"}
       responses:
         "201":
           application/json: {}
@@ -1874,7 +1874,7 @@ examples:
           mesh: "<value>"
           name: "<value>"
       requestBody:
-        application/json: {"mesh": "<value>", "name": "<value>", "type": "<value>"}
+        application/json: {"mesh": "<value>", "name": "<value>", "selectors": [], "type": "<value>"}
       responses:
         "200":
           application/json: {}

--- a/internal/provider/mesh_data_source.go
+++ b/internal/provider/mesh_data_source.go
@@ -374,7 +374,7 @@ func (r *MeshDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 														"expiration": schema.StringAttribute{
 															Computed: true,
 														},
-														"rs_abits": schema.Int64Attribute{
+														"rsa_bits": schema.Int64Attribute{
 															Computed: true,
 														},
 													},

--- a/internal/provider/mesh_data_source_sdk.go
+++ b/internal/provider/mesh_data_source_sdk.go
@@ -254,7 +254,7 @@ func (r *MeshDataSourceModel) RefreshFromSharedMeshItem(resp *shared.MeshItem) {
 						} else {
 							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert = &tfTypes.BuiltinCertificateAuthorityConfigConfCaCert{}
 							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration = types.StringPointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration)
-							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits = types.Int64PointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits)
+							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits = types.Int64PointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits)
 						}
 					}
 					if backendsItem2.Conf.CertManagerCertificateAuthorityConfig != nil {

--- a/internal/provider/mesh_resource.go
+++ b/internal/provider/mesh_resource.go
@@ -8,9 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -22,8 +24,6 @@ import (
 	"github.com/kong/terraform-provider-kong-mesh/internal/sdk"
 	"github.com/kong/terraform-provider-kong-mesh/internal/sdk/models/operations"
 	"github.com/kong/terraform-provider-kong-mesh/internal/validators"
-	speakeasy_objectvalidators "github.com/kong/terraform-provider-kong-mesh/internal/validators/objectvalidators"
-	speakeasy_stringvalidators "github.com/kong/terraform-provider-kong-mesh/internal/validators/stringvalidators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -72,13 +72,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 						Attributes: map[string]schema.Attribute{
 							"requirements": schema.ListNestedAttribute{
 								Optional: true,
-								PlanModifiers: []planmodifier.List{
-									custom_listplanmodifier.SupressZeroNullModifier(),
-								},
 								NestedObject: schema.NestedAttributeObject{
-									Validators: []validator.Object{
-										speakeasy_objectvalidators.NotNull(),
-									},
 									Attributes: map[string]schema.Attribute{
 										"tags": schema.MapAttribute{
 											Optional:    true,
@@ -95,13 +89,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 							},
 							"restrictions": schema.ListNestedAttribute{
 								Optional: true,
-								PlanModifiers: []planmodifier.List{
-									custom_listplanmodifier.SupressZeroNullModifier(),
-								},
 								NestedObject: schema.NestedAttributeObject{
-									Validators: []validator.Object{
-										speakeasy_objectvalidators.NotNull(),
-									},
 									Attributes: map[string]schema.Attribute{
 										"tags": schema.MapAttribute{
 											Optional:    true,
@@ -132,13 +120,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Attributes: map[string]schema.Attribute{
 					"backends": schema.ListNestedAttribute{
 						Optional: true,
-						PlanModifiers: []planmodifier.List{
-							custom_listplanmodifier.SupressZeroNullModifier(),
-						},
 						NestedObject: schema.NestedAttributeObject{
-							Validators: []validator.Object{
-								speakeasy_objectvalidators.NotNull(),
-							},
 							Attributes: map[string]schema.Attribute{
 								"conf": schema.SingleNestedAttribute{
 									Optional: true,
@@ -230,13 +212,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Attributes: map[string]schema.Attribute{
 					"backends": schema.ListNestedAttribute{
 						Optional: true,
-						PlanModifiers: []planmodifier.List{
-							custom_listplanmodifier.SupressZeroNullModifier(),
-						},
 						NestedObject: schema.NestedAttributeObject{
-							Validators: []validator.Object{
-								speakeasy_objectvalidators.NotNull(),
-							},
 							Attributes: map[string]schema.Attribute{
 								"conf": schema.SingleNestedAttribute{
 									Optional: true,
@@ -246,13 +222,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 											Attributes: map[string]schema.Attribute{
 												"aggregate": schema.ListNestedAttribute{
 													Optional: true,
-													PlanModifiers: []planmodifier.List{
-														custom_listplanmodifier.SupressZeroNullModifier(),
-													},
 													NestedObject: schema.NestedAttributeObject{
-														Validators: []validator.Object{
-															speakeasy_objectvalidators.NotNull(),
-														},
 														Attributes: map[string]schema.Attribute{
 															"address": schema.StringAttribute{
 																Optional:    true,
@@ -385,13 +355,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Attributes: map[string]schema.Attribute{
 					"backends": schema.ListNestedAttribute{
 						Optional: true,
-						PlanModifiers: []planmodifier.List{
-							custom_listplanmodifier.SupressZeroNullModifier(),
-						},
 						NestedObject: schema.NestedAttributeObject{
-							Validators: []validator.Object{
-								speakeasy_objectvalidators.NotNull(),
-							},
 							Attributes: map[string]schema.Attribute{
 								"conf": schema.SingleNestedAttribute{
 									Optional: true,
@@ -412,11 +376,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 																	Optional: true,
 																	Attributes: map[string]schema.Attribute{
 																		"type": schema.StringAttribute{
-																			Computed:    true,
-																			Optional:    true,
-																			Description: `Not Null; Parsed as JSON.`,
+																			Required:    true,
+																			Description: `Parsed as JSON.`,
 																			Validators: []validator.String{
-																				speakeasy_stringvalidators.NotNull(),
 																				validators.IsValidJSON(),
 																			},
 																		},
@@ -426,11 +388,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 																	Optional: true,
 																	Attributes: map[string]schema.Attribute{
 																		"type": schema.StringAttribute{
-																			Computed:    true,
-																			Optional:    true,
-																			Description: `Not Null; Parsed as JSON.`,
+																			Required:    true,
+																			Description: `Parsed as JSON.`,
 																			Validators: []validator.String{
-																				speakeasy_stringvalidators.NotNull(),
 																				validators.IsValidJSON(),
 																			},
 																		},
@@ -444,11 +404,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 													Optional: true,
 													Attributes: map[string]schema.Attribute{
 														"type": schema.StringAttribute{
-															Computed:    true,
-															Optional:    true,
-															Description: `Not Null; Parsed as JSON.`,
+															Required:    true,
+															Description: `Parsed as JSON.`,
 															Validators: []validator.String{
-																speakeasy_stringvalidators.NotNull(),
 																validators.IsValidJSON(),
 															},
 														},
@@ -476,7 +434,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 														"expiration": schema.StringAttribute{
 															Optional: true,
 														},
-														"rs_abits": schema.Int64Attribute{
+														"rsa_bits": schema.Int64Attribute{
 															Optional: true,
 														},
 													},
@@ -498,11 +456,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 													Optional: true,
 													Attributes: map[string]schema.Attribute{
 														"type": schema.StringAttribute{
-															Computed:    true,
-															Optional:    true,
-															Description: `Not Null; Parsed as JSON.`,
+															Required:    true,
+															Description: `Parsed as JSON.`,
 															Validators: []validator.String{
-																speakeasy_stringvalidators.NotNull(),
 																validators.IsValidJSON(),
 															},
 														},
@@ -512,10 +468,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 													Optional: true,
 												},
 												"dns_names": schema.ListAttribute{
-													Optional: true,
-													PlanModifiers: []planmodifier.List{
-														custom_listplanmodifier.SupressZeroNullModifier(),
-													},
+													Computed:    true,
+													Optional:    true,
+													Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 													ElementType: types.StringType,
 												},
 												"issuer_ref": schema.SingleNestedAttribute{
@@ -549,11 +504,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 													Optional: true,
 													Attributes: map[string]schema.Attribute{
 														"type": schema.StringAttribute{
-															Computed:    true,
-															Optional:    true,
-															Description: `Not Null; Parsed as JSON.`,
+															Required:    true,
+															Description: `Parsed as JSON.`,
 															Validators: []validator.String{
-																speakeasy_stringvalidators.NotNull(),
 																validators.IsValidJSON(),
 															},
 														},
@@ -563,11 +516,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 													Optional: true,
 													Attributes: map[string]schema.Attribute{
 														"type": schema.StringAttribute{
-															Computed:    true,
-															Optional:    true,
-															Description: `Not Null; Parsed as JSON.`,
+															Required:    true,
+															Description: `Parsed as JSON.`,
 															Validators: []validator.String{
-																speakeasy_stringvalidators.NotNull(),
 																validators.IsValidJSON(),
 															},
 														},
@@ -744,10 +695,9 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Description: `Routing settings of the mesh`,
 			},
 			"skip_creating_initial_policies": schema.ListAttribute{
-				Optional: true,
-				PlanModifiers: []planmodifier.List{
-					custom_listplanmodifier.SupressZeroNullModifier(),
-				},
+				Computed:    true,
+				Optional:    true,
+				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 				ElementType: types.StringType,
 				MarkdownDescription: `List of policies to skip creating by default when the mesh is created.` + "\n" +
 					`e.g. TrafficPermission, MeshRetry, etc. An '*' can be used to skip all` + "\n" +
@@ -758,13 +708,7 @@ func (r *MeshResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Attributes: map[string]schema.Attribute{
 					"backends": schema.ListNestedAttribute{
 						Optional: true,
-						PlanModifiers: []planmodifier.List{
-							custom_listplanmodifier.SupressZeroNullModifier(),
-						},
 						NestedObject: schema.NestedAttributeObject{
-							Validators: []validator.Object{
-								speakeasy_objectvalidators.NotNull(),
-							},
 							Attributes: map[string]schema.Attribute{
 								"conf": schema.SingleNestedAttribute{
 									Optional: true,

--- a/internal/provider/mesh_resource_sdk.go
+++ b/internal/provider/mesh_resource_sdk.go
@@ -371,21 +371,21 @@ func (r *MeshResourceModel) ToSharedMeshItem() *shared.MeshItem {
 				if backendsItem2.Conf.BuiltinCertificateAuthorityConfig != nil {
 					var caCert *shared.BuiltinCertificateAuthorityConfigConfCaCert
 					if backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert != nil {
-						rsAbits := new(int64)
-						if !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits.IsUnknown() && !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits.IsNull() {
-							*rsAbits = backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits.ValueInt64()
-						} else {
-							rsAbits = nil
-						}
 						expiration := new(string)
 						if !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.IsUnknown() && !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.IsNull() {
 							*expiration = backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.ValueString()
 						} else {
 							expiration = nil
 						}
+						rsaBits := new(int64)
+						if !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.IsUnknown() && !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.IsNull() {
+							*rsaBits = backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.ValueInt64()
+						} else {
+							rsaBits = nil
+						}
 						caCert = &shared.BuiltinCertificateAuthorityConfigConfCaCert{
-							RSAbits:    rsAbits,
 							Expiration: expiration,
+							RsaBits:    rsaBits,
 						}
 					}
 					builtinCertificateAuthorityConfig = &shared.BuiltinCertificateAuthorityConfig{
@@ -1097,7 +1097,7 @@ func (r *MeshResourceModel) RefreshFromSharedMeshItem(resp *shared.MeshItem) {
 						} else {
 							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert = &tfTypes.BuiltinCertificateAuthorityConfigConfCaCert{}
 							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration = types.StringPointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration)
-							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits = types.Int64PointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits)
+							backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits = types.Int64PointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits)
 						}
 					}
 					if backendsItem2.Conf.CertManagerCertificateAuthorityConfig != nil {

--- a/internal/provider/meshgateway_resource.go
+++ b/internal/provider/meshgateway_resource.go
@@ -22,8 +22,6 @@ import (
 	"github.com/kong/terraform-provider-kong-mesh/internal/sdk"
 	"github.com/kong/terraform-provider-kong-mesh/internal/sdk/models/operations"
 	"github.com/kong/terraform-provider-kong-mesh/internal/validators"
-	speakeasy_objectvalidators "github.com/kong/terraform-provider-kong-mesh/internal/validators/objectvalidators"
-	speakeasy_stringvalidators "github.com/kong/terraform-provider-kong-mesh/internal/validators/stringvalidators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -64,13 +62,7 @@ func (r *MeshGatewayResource) Schema(ctx context.Context, req resource.SchemaReq
 				Attributes: map[string]schema.Attribute{
 					"listeners": schema.ListNestedAttribute{
 						Optional: true,
-						PlanModifiers: []planmodifier.List{
-							custom_listplanmodifier.SupressZeroNullModifier(),
-						},
 						NestedObject: schema.NestedAttributeObject{
-							Validators: []validator.Object{
-								speakeasy_objectvalidators.NotNull(),
-							},
 							Attributes: map[string]schema.Attribute{
 								"cross_mesh": schema.BoolAttribute{
 									Optional: true,
@@ -136,25 +128,18 @@ func (r *MeshGatewayResource) Schema(ctx context.Context, req resource.SchemaReq
 									Attributes: map[string]schema.Attribute{
 										"certificates": schema.ListNestedAttribute{
 											Optional: true,
-											PlanModifiers: []planmodifier.List{
-												custom_listplanmodifier.SupressZeroNullModifier(),
-											},
 											NestedObject: schema.NestedAttributeObject{
-												Validators: []validator.Object{
-													speakeasy_objectvalidators.NotNull(),
-												},
 												Attributes: map[string]schema.Attribute{
 													"type": schema.StringAttribute{
-														Optional: true,
+														Required: true,
 														MarkdownDescription: `Types that are assignable to Type:` + "\n" +
 															`` + "\n" +
 															`	*DataSource_Secret` + "\n" +
 															`	*DataSource_File` + "\n" +
 															`	*DataSource_Inline` + "\n" +
 															`	*DataSource_InlineString` + "\n" +
-															`Not Null; Parsed as JSON.`,
+															`Parsed as JSON.`,
 														Validators: []validator.String{
-															speakeasy_stringvalidators.NotNull(),
 															validators.IsValidJSON(),
 														},
 													},
@@ -234,13 +219,7 @@ func (r *MeshGatewayResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"selectors": schema.ListNestedAttribute{
 				Optional: true,
-				PlanModifiers: []planmodifier.List{
-					custom_listplanmodifier.SupressZeroNullModifier(),
-				},
 				NestedObject: schema.NestedAttributeObject{
-					Validators: []validator.Object{
-						speakeasy_objectvalidators.NotNull(),
-					},
 					Attributes: map[string]schema.Attribute{
 						"match": schema.MapAttribute{
 							Optional:    true,

--- a/internal/provider/meshlist_data_source.go
+++ b/internal/provider/meshlist_data_source.go
@@ -373,7 +373,7 @@ func (r *MeshListDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 																	"expiration": schema.StringAttribute{
 																		Computed: true,
 																	},
-																	"rs_abits": schema.Int64Attribute{
+																	"rsa_bits": schema.Int64Attribute{
 																		Computed: true,
 																	},
 																},

--- a/internal/provider/meshlist_data_source_sdk.go
+++ b/internal/provider/meshlist_data_source_sdk.go
@@ -245,7 +245,7 @@ func (r *MeshListDataSourceModel) RefreshFromSharedMeshList(resp *shared.MeshLis
 							} else {
 								backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert = &tfTypes.BuiltinCertificateAuthorityConfigConfCaCert{}
 								backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration = types.StringPointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration)
-								backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits = types.Int64PointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RSAbits)
+								backends5.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits = types.Int64PointerValue(backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits)
 							}
 						}
 						if backendsItem2.Conf.CertManagerCertificateAuthorityConfig != nil {

--- a/internal/provider/types/builtin_certificate_authority_config_conf_ca_cert.go
+++ b/internal/provider/types/builtin_certificate_authority_config_conf_ca_cert.go
@@ -6,5 +6,5 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type BuiltinCertificateAuthorityConfigConfCaCert struct {
 	Expiration types.String `tfsdk:"expiration"`
-	RSAbits    types.Int64  `tfsdk:"rs_abits"`
+	RsaBits    types.Int64  `tfsdk:"rsa_bits"`
 }

--- a/internal/sdk/models/shared/meshitem.go
+++ b/internal/sdk/models/shared/meshitem.go
@@ -813,15 +813,8 @@ func (o *VaultCertificateAuthorityConfig) GetMode() any {
 }
 
 type BuiltinCertificateAuthorityConfigConfCaCert struct {
-	RSAbits    *int64  `json:"RSAbits,omitempty"`
 	Expiration *string `json:"expiration,omitempty"`
-}
-
-func (o *BuiltinCertificateAuthorityConfigConfCaCert) GetRSAbits() *int64 {
-	if o == nil {
-		return nil
-	}
-	return o.RSAbits
+	RsaBits    *int64  `json:"rsaBits,omitempty"`
 }
 
 func (o *BuiltinCertificateAuthorityConfigConfCaCert) GetExpiration() *string {
@@ -829,6 +822,13 @@ func (o *BuiltinCertificateAuthorityConfigConfCaCert) GetExpiration() *string {
 		return nil
 	}
 	return o.Expiration
+}
+
+func (o *BuiltinCertificateAuthorityConfigConfCaCert) GetRsaBits() *int64 {
+	if o == nil {
+		return nil
+	}
+	return o.RsaBits
 }
 
 type BuiltinCertificateAuthorityConfig struct {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13534,12 +13534,12 @@ components:
       properties:
         caCert:
           properties:
-            RSAbits:
-              format: uint32
-              type: integer
-              x-speakeasy-param-computed: false
             expiration:
               type: string
+              x-speakeasy-param-computed: false
+            rsaBits:
+              format: uint32
+              type: integer
               x-speakeasy-param-computed: false
           type: object
           x-speakeasy-param-computed: false
@@ -13599,8 +13599,9 @@ components:
                         type: object
                         x-speakeasy-param-computed: false
                     type: object
+                    x-speakeasy-param-computed: false
                   type: array
-                  x-speakeasy-plan-modifiers: SupressZeroNullModifier
+                  default: []
                   x-speakeasy-param-computed: false
                 restrictions:
                   description: |-
@@ -13620,8 +13621,9 @@ components:
                         type: object
                         x-speakeasy-param-computed: false
                     type: object
+                    x-speakeasy-param-computed: false
                   type: array
-                  x-speakeasy-plan-modifiers: SupressZeroNullModifier
+                  default: []
                   x-speakeasy-param-computed: false
               type: object
               x-speakeasy-param-computed: false
@@ -13665,8 +13667,9 @@ components:
                     type: string
                     x-speakeasy-param-computed: false
                 type: object
+                x-speakeasy-param-computed: false
               type: array
-              x-speakeasy-plan-modifiers: SupressZeroNullModifier
+              default: []
               x-speakeasy-param-computed: false
             defaultBackend:
               description: Name of the default backend
@@ -13711,8 +13714,9 @@ components:
                     type: string
                     x-speakeasy-param-computed: false
                 type: object
+                x-speakeasy-param-computed: false
               type: array
-              x-speakeasy-plan-modifiers: SupressZeroNullModifier
+              default: []
               x-speakeasy-param-computed: false
             enabledBackend:
               description: Name of the enabled backend
@@ -13800,8 +13804,9 @@ components:
                     type: string
                     x-speakeasy-param-computed: false
                 type: object
+                x-speakeasy-param-computed: false
               type: array
-              x-speakeasy-plan-modifiers: SupressZeroNullModifier
+              default: []
               x-speakeasy-param-computed: false
             enabledBackend:
               description: Name of the enabled backend
@@ -13859,8 +13864,9 @@ components:
             policies.
           items:
             type: string
+            x-speakeasy-param-computed: false
           type: array
-          x-speakeasy-plan-modifiers: SupressZeroNullModifier
+          default: []
           x-speakeasy-param-computed: false
         tracing:
           description: |-
@@ -13895,8 +13901,9 @@ components:
                     type: string
                     x-speakeasy-param-computed: false
                 type: object
+                x-speakeasy-param-computed: false
               type: array
-              x-speakeasy-plan-modifiers: SupressZeroNullModifier
+              default: []
               x-speakeasy-param-computed: false
             defaultBackend:
               description: Name of the default backend
@@ -13967,8 +13974,9 @@ components:
                 type: integer
                 x-speakeasy-param-computed: false
             type: object
+            x-speakeasy-param-computed: false
           type: array
-          x-speakeasy-plan-modifiers: SupressZeroNullModifier
+          default: []
           x-speakeasy-param-computed: false
         envoy:
           description: Configuration of Envoy's metrics.
@@ -14160,8 +14168,9 @@ components:
                           required:
                             - Type
                           type: object
+                          x-speakeasy-param-computed: false
                         type: array
-                        x-speakeasy-plan-modifiers: SupressZeroNullModifier
+                        default: []
                         x-speakeasy-param-computed: false
                       mode:
                         description: |-
@@ -14182,8 +14191,9 @@ components:
                     type: object
                     x-speakeasy-param-computed: false
                 type: object
+                x-speakeasy-param-computed: false
               type: array
-              x-speakeasy-plan-modifiers: SupressZeroNullModifier
+              default: []
               x-speakeasy-param-computed: false
           type: object
           x-speakeasy-param-computed: false
@@ -14214,8 +14224,9 @@ components:
                 type: object
                 x-speakeasy-param-computed: false
             type: object
+            x-speakeasy-param-computed: false
           type: array
-          x-speakeasy-plan-modifiers: SupressZeroNullModifier
+          default: []
           x-speakeasy-param-computed: false
         tags:
           additionalProperties:
@@ -15297,8 +15308,9 @@ components:
         dnsNames:
           items:
             type: string
+            x-speakeasy-param-computed: false
           type: array
-          x-speakeasy-plan-modifiers: SupressZeroNullModifier
+          default: []
           x-speakeasy-param-computed: false
         issuerRef:
           properties:


### PR DESCRIPTION
sync platform api that instead of using SupressZeroNullModifier on protobuf arrays uses default

xrel: https://github.com/Kong/platform-api/pull/1233

