### PR TITLE
chore(release): kick off release 0.4.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 2.0.0
   speakeasyVersion: 1.551.0
   generationVersion: 2.610.0
-  releaseVersion: 0.3.0
-  configChecksum: 7d1de1478aec91650e1f75c8433c38d6
+  releaseVersion: 0.4.0
+  configChecksum: 895f678a350fe1df7294c024aaecd4a3
 features:
   terraform:
     additionalDependencies: 0.1.0

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -6,7 +6,7 @@ management:
   speakeasyVersion: 1.551.0
   generationVersion: 2.610.0
   releaseVersion: 0.4.0
-  configChecksum: 895f678a350fe1df7294c024aaecd4a3
+  configChecksum: 5314498bbcbbd8ab2380018b45e9c27d
 features:
   terraform:
     additionalDependencies: 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0
+> Released on 2025/05/29
+>
+> - Add hook that defaults `skip_creating_initial_policies`
+
 ## 0.3.0
 > Released on 2025/05/27
 >

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kong-mesh = {
       source  = "kong/kong-mesh"
-      version = "0.3.0"
+      version = "0.4.0"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -26,7 +26,7 @@ go:
       github.com/Kong/shared-speakeasy/planmodifiers/suppress_zero_null: v0.0.1
       github.com/Kong/shared-speakeasy/tfbuilder: v0.0.4
 terraform:
-  version: 0.3.0
+  version: 0.4.0
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/gen.yaml
+++ b/gen.yaml
@@ -21,7 +21,7 @@ go:
   additionalDependencies:
     dependencies:
       github.com/Kong/shared-speakeasy/customtypes: v0.2.2
-      github.com/Kong/shared-speakeasy/hooks/mesh_defaults: v0.0.1
+      github.com/Kong/shared-speakeasy/hooks/mesh_defaults: v0.0.3
       github.com/Kong/shared-speakeasy/planmodifiers/arbitrary_json: v0.0.1
       github.com/Kong/shared-speakeasy/planmodifiers/suppress_zero_null: v0.0.1
       github.com/Kong/shared-speakeasy/tfbuilder: v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.1
 
 require (
 	github.com/Kong/shared-speakeasy/customtypes v0.2.2
+	github.com/Kong/shared-speakeasy/hooks/mesh_defaults v0.0.3
 	github.com/Kong/shared-speakeasy/planmodifiers/arbitrary_json v0.0.1
 	github.com/Kong/shared-speakeasy/planmodifiers/suppress_zero_null v0.0.1
 	github.com/Kong/shared-speakeasy/tfbuilder v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Kong/shared-speakeasy/customtypes v0.2.2 h1:GwDbzXaH1RVs2L/62EwC11EgWYzba54ZO7J6vrkoatI=
 github.com/Kong/shared-speakeasy/customtypes v0.2.2/go.mod h1:fLy23iYs9rUWZqFGbu7yQYrWL8rbCOJrLISBzqpxVhk=
+github.com/Kong/shared-speakeasy/hooks/mesh_defaults v0.0.3 h1:+wYc79YT0VlV/7BbW9tcZSIfCBGj+4twtm2bPzVj+vo=
+github.com/Kong/shared-speakeasy/hooks/mesh_defaults v0.0.3/go.mod h1:Tu9kdp+k8JF7ES5gcXBi6jHyLEOr1EAAWq8ROOipWqg=
 github.com/Kong/shared-speakeasy/planmodifiers/arbitrary_json v0.0.1 h1:S3f3RAPNv274Yd8ShkGjSTXLWS55AY1SHNKfcX8sQjU=
 github.com/Kong/shared-speakeasy/planmodifiers/arbitrary_json v0.0.1/go.mod h1:exogJpiSOmoVk8BTkYA2wlkvqhYlOP+LJpXc4CacHuU=
 github.com/Kong/shared-speakeasy/planmodifiers/suppress_zero_null v0.0.1 h1:2PxZAhqgCU0dz+qjghtay2XkNLx2F3oEuh90U/acijc=

--- a/internal/sdk/internal/hooks/mesh_defaults_hook.go
+++ b/internal/sdk/internal/hooks/mesh_defaults_hook.go
@@ -1,0 +1,17 @@
+package hooks
+
+import (
+	shared_speakeasy "github.com/Kong/shared-speakeasy/hooks/mesh_defaults"
+	"net/http"
+)
+
+// MeshDefaultsHook is a struct that implements the BeforeRequestHook interface.
+type MeshDefaultsHook struct{}
+
+// BeforeRequest modifies the request before sending it.
+func (e MeshDefaultsHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
+	apiPrefix := ""
+	cpFeatures := false
+	initialPolicies := true
+	return shared_speakeasy.BeforeRequest(apiPrefix, cpFeatures, initialPolicies)(req)
+}

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -1,18 +1,5 @@
 package hooks
 
-/*
- * This file is only ever generated once on the first generation and then is free to be modified.
- * Any hooks you wish to add should be registered in the initHooks function. Feel free to define
- * your hooks in this file or in separate files in the hooks package.
- *
- * Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance.
- */
-
 func initHooks(h *Hooks) {
-	// exampleHook := &ExampleHook{}
-
-	// h.registerSDKInitHook(exampleHook)
-	// h.registerBeforeRequestHook(exampleHook)
-	// h.registerAfterErrorHook(exampleHook)
-	// h.registerAfterSuccessHook(exampleHook)
+	h.registerBeforeRequestHook(&MeshDefaultsHook{})
 }

--- a/internal/sdk/kongmesh.go
+++ b/internal/sdk/kongmesh.go
@@ -123,9 +123,9 @@ func New(serverURL string, opts ...SDKOption) *KongMesh {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "go",
 			OpenAPIDocVersion: "2.0.0",
-			SDKVersion:        "0.3.0",
+			SDKVersion:        "0.4.0",
 			GenVersion:        "2.610.0",
-			UserAgent:         "speakeasy-sdk/terraform 0.3.0 2.610.0 2.0.0 github.com/kong/terraform-provider-kong-mesh/internal/sdk",
+			UserAgent:         "speakeasy-sdk/terraform 0.4.0 2.610.0 2.0.0 github.com/kong/terraform-provider-kong-mesh/internal/sdk",
 			ServerURL:         serverURL,
 			Hooks:             hooks.New(),
 		},

--- a/tests/resources/mesh_test.go
+++ b/tests/resources/mesh_test.go
@@ -39,14 +39,16 @@ func TestMesh(t *testing.T) {
 
 	t.Run("create a mesh and modify fields on it", func(t *testing.T) {
 		builder := tfbuilder.NewBuilder(tfbuilder.KongMesh, "http", "localhost", port.Int())
-		mesh := tfbuilder.NewMeshBuilder("m1", "m1")
+		mesh := tfbuilder.NewMeshBuilder("m1", "m1").
+			WithSpec(`skip_creating_initial_policies = [ "*" ]`)
 
 		resource.ParallelTest(t, tfbuilder.CreateMeshAndModifyFieldsOnIt(providerFactory, builder, mesh))
 	})
 
 	t.Run("create a policy and modify fields on it", func(t *testing.T) {
 		builder := tfbuilder.NewBuilder(tfbuilder.KongMesh, "http", "localhost", port.Int())
-		mesh := tfbuilder.NewMeshBuilder("default", "terraform-provider-kong-mesh")
+		mesh := tfbuilder.NewMeshBuilder("default", "terraform-provider-kong-mesh").
+			WithSpec(`skip_creating_initial_policies = [ "*" ]`)
 		mtp := tfbuilder.NewPolicyBuilder("mesh_traffic_permission", "allow_all", "allow-all", "MeshTrafficPermission").
 			WithMeshRef(builder.ResourceAddress("mesh", mesh.ResourceName) + ".name").
 			WithDependsOn(builder.ResourceAddress("mesh", mesh.ResourceName))
@@ -60,7 +62,8 @@ func TestMesh(t *testing.T) {
 		mtpName := "allow-all"
 
 		builder := tfbuilder.NewBuilder(tfbuilder.KongMesh, "http", "localhost", port.Int())
-		mesh := tfbuilder.NewMeshBuilder("default", meshName)
+		mesh := tfbuilder.NewMeshBuilder("default", meshName).
+			WithSpec(`skip_creating_initial_policies = [ "*" ]`)
 		mtp := tfbuilder.NewPolicyBuilder("mesh_traffic_permission", "allow_all", mtpName, "MeshTrafficPermission").
 			WithMeshRef(builder.ResourceAddress("mesh", mesh.ResourceName) + ".name").
 			WithDependsOn(builder.ResourceAddress("mesh", mesh.ResourceName))


### PR DESCRIPTION
Includes a hook to default `skip_creating_initial_policies` so that a Mesh created with TF is created without any policies.

Closes https://github.com/Kong/terraform-provider-kong-mesh/issues/22