### PR TITLE
ci(workflow): run acceptance tests on main as well

### DIFF
--- a/.github/workflows/provider-tests.yaml
+++ b/.github/workflows/provider-tests.yaml
@@ -1,6 +1,9 @@
 name: Terraform Provider Tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
If we mess up something like in https://github.com/Kong/terraform-provider-kong-mesh/issues/69 then we will only know on the next PR 