### PR TITLE
chore(ci): add permissions for lifecycle job

### DIFF
--- a/.github/workflows/lifecycle.yaml
+++ b/.github/workflows/lifecycle.yaml
@@ -8,12 +8,15 @@ on:
       - reopened
       - opened
       - labeled
-permissions:
-  contents: read
+permissions: {}
+
 jobs:
   lifecycle:
     permissions:
+      actions: read
+      contents: write
       issues: write
+      pull-requests: write
     uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@ec5a7f83fb1f5b03707118050147a70fd115c231
     with:
       filesToIgnore: CONTRIBUTING.md


### PR DESCRIPTION
Updated permissions for GitHub Actions in lifecycle workflow, since it was failing 

https://github.com/Kong/mink-charts/blob/main/.github/workflows/lifecycle.yml