### PR TITLE
chore(deps): bump shared-speakeasy/customtypes to v0.2.5

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -6,7 +6,7 @@ management:
   speakeasyVersion: 1.642.1
   generationVersion: 2.731.4
   releaseVersion: 0.6.2
-  configChecksum: 015f1f813ea89010a6bb550bf0272722
+  configChecksum: 993eee78520efebda593bf0e3484ab1c
 features:
   terraform:
     additionalDependencies: 0.1.0

--- a/gen.yaml
+++ b/gen.yaml
@@ -30,7 +30,7 @@ terraform:
   version: 0.6.2
   additionalDataSources: []
   additionalDependencies:
-    github.com/Kong/shared-speakeasy/customtypes: v0.3.0
+    github.com/Kong/shared-speakeasy/customtypes: v0.2.5
     github.com/Kong/shared-speakeasy/hooks/mesh_defaults: v0.0.4
     github.com/Kong/shared-speakeasy/planmodifiers/arbitrary_json: v0.0.1
     github.com/Kong/shared-speakeasy/planmodifiers/suppress_zero_null: v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kong/terraform-provider-kong-mesh
 go 1.24.1
 
 require (
-	github.com/Kong/shared-speakeasy/customtypes v0.3.0
+	github.com/Kong/shared-speakeasy/customtypes v0.2.5
 	github.com/Kong/shared-speakeasy/hooks/mesh_defaults v0.0.4
 	github.com/Kong/shared-speakeasy/planmodifiers/arbitrary_json v0.0.1
 	github.com/Kong/shared-speakeasy/planmodifiers/suppress_zero_null v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/Kong/shared-speakeasy/customtypes v0.3.0 h1:3wHKa0mvv/UTCnIrV+s0RqjRVsSNMU6RIee0kDOylbs=
-github.com/Kong/shared-speakeasy/customtypes v0.3.0/go.mod h1:JNv+ygEk9Dw3MyZLNxHSJS3Wo7HMexOSP2qH6kfaZhI=
+github.com/Kong/shared-speakeasy/customtypes v0.2.5 h1:VxMhCPyaOcU/Utd2RqLi4xOxz9Sf+4xA9sXJbBPGszA=
+github.com/Kong/shared-speakeasy/customtypes v0.2.5/go.mod h1:JNv+ygEk9Dw3MyZLNxHSJS3Wo7HMexOSP2qH6kfaZhI=
 github.com/Kong/shared-speakeasy/hooks/mesh_defaults v0.0.4 h1:BIlFfdeqRP33wP5GOSwLxFPujL4C1GozoIjZMpzZXj0=
 github.com/Kong/shared-speakeasy/hooks/mesh_defaults v0.0.4/go.mod h1:Tu9kdp+k8JF7ES5gcXBi6jHyLEOr1EAAWq8ROOipWqg=
 github.com/Kong/shared-speakeasy/planmodifiers/arbitrary_json v0.0.1 h1:S3f3RAPNv274Yd8ShkGjSTXLWS55AY1SHNKfcX8sQjU=


### PR DESCRIPTION
### Summary

Future PR from platform-api is going to add `x-speakeasy-terraform-custom-default` extension with custom type `kumalabels.EmptyKumaLabelsMapDefault{}`. We have to bump shared-speakeasy/customtypes version first, so the update won't fail.

Changes we need in shared-speakeasy/customtypes v.0.2.5:
* https://github.com/Kong/shared-speakeasy/pull/45