### PR TITLE
ci(speakeasy): run on mesh-v3 branches

### DIFF
--- a/.github/workflows/generate-speakeasy-on-pr.yaml
+++ b/.github/workflows/generate-speakeasy-on-pr.yaml
@@ -22,6 +22,8 @@ jobs:
       REF: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
     name: Run Speakeasy on PR Open
     if: github.event.pull_request.head.ref == 'feat/platform-api-automated-update' ||
+      github.event.pull_request.head.ref == 'feat/platform-api-automated-update-mesh-v3' ||
+      github.event.pull_request.head.ref == 'mesh-v3' ||
       github.event_name == 'workflow_dispatch' ||
       github.actor == 'renovate[bot]' ||
       github.actor == 'mend[bot]'
@@ -31,7 +33,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Install Speakeasy
-        uses: mheap/setup-go-cli@fa9b01cdd4115eac636164f0de43bf7d51c82697 # v1
+        uses: mheap/setup-go-cli@fa9b01cdd4115eac636164f0de43bf7d51c82697 # v1.2.2
         with:
           owner: speakeasy-api
           repo: speakeasy


### PR DESCRIPTION
## Motivation

The speakeasy-on-PR workflow only fires when the PR head branch is `feat/platform-api-automated-update`, so mesh-v3 PRs never get generated code.

## Implementation information

Adds two more branches to the head-ref gate:

- `feat/platform-api-automated-update-mesh-v3`
- `mesh-v3`

Also spells out the `mheap/setup-go-cli` pin comment as `v1.2.2` (the tag that digest actually points at) - the repo's workflow linter rejects the short `v1` form, so the file couldn't be edited without it.

Note the `workflow_dispatch` input still defaults to `feat/platform-api-automated-update`; it's still overridable at dispatch time, let me know if you want the default changed too.

## Supporting documentation

N/A

> Changelog: skip